### PR TITLE
Fix #1 - Use .net Standard SDK instead of .net Core

### DIFF
--- a/src/WcfCoreMtomEncoder/WcfCoreMtomEncoder.csproj
+++ b/src/WcfCoreMtomEncoder/WcfCoreMtomEncoder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <Description>MTOM message encoder for .NET Core WCF</Description>
     <Authors>Lenny Kean</Authors>


### PR DESCRIPTION
Allows consuming this library from .netstandard applications in addition to .net core ones.