### PR TITLE
Fix #6 - Handle trailing semicolons in Content-Type headers

### DIFF
--- a/src/WcfCoreMtomEncoder/MtomPart.cs
+++ b/src/WcfCoreMtomEncoder/MtomPart.cs
@@ -24,8 +24,7 @@ namespace WcfCoreMtomEncoder
             {
                 string contentTypeHeaderValue = _part.Headers.GetValues("Content-Type").FirstOrDefault();
 
-                MediaTypeHeaderValue parsedValue;
-                if (!String.IsNullOrEmpty(contentTypeHeaderValue) && MediaTypeHeaderValue.TryParse(contentTypeHeaderValue.TrimEnd(';'), out parsedValue))
+                if (!String.IsNullOrEmpty(contentTypeHeaderValue) && MediaTypeHeaderValue.TryParse(contentTypeHeaderValue.TrimEnd(';'), out var parsedValue))
                     return parsedValue;
 
                 return _part.Headers.ContentType;
@@ -45,9 +44,11 @@ namespace WcfCoreMtomEncoder
 
         public string GetStringContentForEncoder(MessageEncoder encoder)
         {
-            if (ContentType == null || 
+            if (ContentType == null ||
                 !ContentType.Parameters.Any(p => p.Name == "type" && encoder.IsContentTypeSupported(p.Value.Replace("\"", ""))))
+            {
                 throw new NotSupportedException();
+            }
 
             var encoding = ContentType.CharSet != null ? Encoding.GetEncoding(ContentType.CharSet) : Encoding.Default;
 


### PR DESCRIPTION
Many implementations out there return a trailing semicolon in the Content-Type headers in multipart messages. Since .net core follows the specs and doesn't recognize them, the library does not deserialize them correctly. This pull request adds some code to make it more forgiving.